### PR TITLE
Add GameConfig struct

### DIFF
--- a/examples/solo_cli.rs
+++ b/examples/solo_cli.rs
@@ -119,10 +119,10 @@ fn main() {
 
     let mut dealer: Dealer;
 
-    dealer = Dealer::new(shoe, &callback);
+    dealer = Dealer::new(shoe, DEFAULT_CONFIG, &callback);
     dealer.players_mut().push(player);
 
     loop {
-        dealer.play_round(true, true);
+        dealer.play_round(true);
     }
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -181,14 +181,11 @@ impl Dealer<'_> {
 
     /// Deal a hand to all players
     pub fn deal_hands(&mut self) {
-        // Dealer's hand
-        cards::hit_card(&mut self.shoe, &mut self.hand);
-        cards::hit_card(&mut self.shoe, &mut self.hand);
-
-        // Players' hands
-        for player in self.players.iter_mut() {
-            cards::hit_card(&mut self.shoe, &mut player.hands_mut()[0]);
-            cards::hit_card(&mut self.shoe, &mut player.hands_mut()[0]);
+        for _ in 0..2 {
+            cards::hit_card(&mut self.shoe, &mut self.hand);
+            for player in self.players.iter_mut() {
+                cards::hit_card(&mut self.shoe, &mut player.hands_mut()[0]);
+            }
         }
     }
 
@@ -253,6 +250,10 @@ impl Dealer<'_> {
             // Keep track of stood hands
             let mut stood = vec![false];
 
+            // Keep track of original bet
+            // Used when doubling after splitting
+            let original_bet = player_bets[i];
+
             // Active hand
             let mut hand_count = 1;
             let mut j = 0;
@@ -274,8 +275,8 @@ impl Dealer<'_> {
                         PlayerAction::Stand => stood[j] = true,
                         PlayerAction::DoubleDown => {
                             if can_double[j] {
-                                *self.players[i].money_mut() -= player_bets[i];
-                                player_bets[i] *= 2;
+                                *self.players[i].money_mut() -= original_bet;
+                                player_bets[i] += original_bet;
                                 stood[j] = true;
                                 self.hit_card(i, j);
                                 can_double[j] = false;
@@ -291,8 +292,8 @@ impl Dealer<'_> {
                         }
                         PlayerAction::Split => {
                             if can_split {
-                                *self.players[i].money_mut() -= player_bets[i];
-                                player_bets[i] *= 2;
+                                *self.players[i].money_mut() -= original_bet;
+                                player_bets[i] += original_bet;
                                 self.players[i].hands_mut().push(Vec::new());
                                 stood.push(false);
                                 if self.config.double_after_split {

--- a/src/game.rs
+++ b/src/game.rs
@@ -68,9 +68,9 @@ pub struct GameConfig {
 
 /// A default configuration for game settings.
 ///
-/// Stands on soft 17, pays out blackjacks 3 to 2, allows doubling after splitting,
+/// Stands on soft 17, pays out blackjacks 3 to 2, and allows doubling after splitting.
 pub const DEFAULT_CONFIG: GameConfig = GameConfig {
-    stand_soft_17: false,
+    stand_soft_17: true,
     blackjack_payout: 1.5,
     double_after_split: true,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@
 //!     shuffle_deck(&mut shoe);
 //!
 //!     // Create a dealer
-//!     let mut dealer = Dealer::new(shoe, &callback);
+//!     let mut dealer = Dealer::new(shoe, DEFAULT_CONFIG, &callback);
 //!     // Create a player with $1000
 //!     let player = Player::new(1000);
 //!     // Add the player to the dealer
@@ -75,7 +75,7 @@
 //!
 //!     // Auto-play five rounds
 //!     for _ in 0..5 {
-//!         dealer.play_round(true, true);
+//!         dealer.play_round(true);
 //!     }
 //! }
 //!

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -94,7 +94,7 @@ mod tests {
 
         let mut shoe = cards::create_shoe(6);
         cards::shuffle_deck(&mut shoe);
-        let mut dealer = Dealer::new(shoe, &callback);
+        let mut dealer = Dealer::new(shoe, game::DEFAULT_CONFIG, &callback);
         // Mutable reference to players vector
         let players = dealer.players_mut();
 
@@ -104,7 +104,7 @@ mod tests {
         // Try playing 5 rounds
         for _ in 0..5 {
             println!("--- New Round ---");
-            dealer.play_round(true, true);
+            dealer.play_round(true);
         }
     }
 }


### PR DESCRIPTION
Adds a structure used to configure the game more precisely.

- Lets you allow/disallow doubling after split
- Lets you choose whether to stand or hit on soft 17
- Lets you edit the blackjack payout multiplier